### PR TITLE
ApiController registerComponentAction fails to determine remote ip in case of sitting behind a proxy

### DIFF
--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -790,7 +790,7 @@ class ApiController extends Zend_Controller_Action
         $request = $this->getRequest();
 
         $component = $request->getParam('component');
-        $remoteAddr = $_SERVER['REMOTE_ADDR'];
+        $remoteAddr = Application_Model_ServiceRegister::GetRemoteIpAddr();
         Logging::log("Registered Component: ".$component."@".$remoteAddr);
 
         Application_Model_ServiceRegister::Register($component, $remoteAddr);

--- a/airtime_mvc/application/models/ServiceRegister.php
+++ b/airtime_mvc/application/models/ServiceRegister.php
@@ -1,6 +1,20 @@
 <?php
 class Application_Model_ServiceRegister {
 
+    public static function GetRemoteIpAddr(){
+
+        if (!empty($_SERVER['HTTP_CLIENT_IP'])){
+            //check ip from share internet
+            $ip=$_SERVER['HTTP_CLIENT_IP'];
+        }elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])){
+            //to check ip is pass from proxy
+            $ip=$_SERVER['HTTP_X_FORWARDED_FOR'];
+        }else{
+            $ip=$_SERVER['REMOTE_ADDR'];
+        }
+        return $ip;
+    }
+
     public static function Register($p_componentName, $p_ipAddress){
 
         $component = CcServiceRegisterQuery::create()->findOneByDbName($p_componentName);


### PR DESCRIPTION
Hi!

When airtime-playout service and airtime zend backend application are running on different hosts, and when airtime zend backend is running behind a proxy (nginx for example), the airtime-playout service ip is determined incorrectly in ApiController registerComponentAction.

because $_SERVER['REMOTE_ADDR'] becomes 127.0.0.1 in that case. (ApiController::registerComponentAction line 793)

provided fix is to check $_SERVER['HTTP_X_FORWARDED_FOR'] and $_SERVER['HTTP_CLIENT_IP'] before falling back to $_SERVER['REMOTE_ADDR'].

Thanks!
Vladimir.
