### PR TITLE
Api client refactor

### DIFF
--- a/python_apps/api_clients/api_client.py
+++ b/python_apps/api_clients/api_client.py
@@ -84,7 +84,7 @@ class ApiRequest(object):
         response  = urllib2.urlopen(final_url).read()
         return response
 
-def RequestProvider(object):
+class RequestProvider(object):
     """ Creates the available ApiRequest instance that can be read from
     a config file """
     def __init__(self, cfg):

--- a/python_apps/api_clients/api_client.py
+++ b/python_apps/api_clients/api_client.py
@@ -75,7 +75,7 @@ class ApcUrl(object):
         if '%%' in self.base_url: raise IncompleteUrl(self.base_url)
         else: return self.base_url
 
-def ApiRequest(object):
+class ApiRequest(object):
     def __init__(self, name, url):
         self.name = name
         self.url  = url

--- a/python_apps/api_clients/api_client.py
+++ b/python_apps/api_clients/api_client.py
@@ -67,7 +67,7 @@ class ApcUrl(object):
         for k, v in params.iteritems():
             wrapped_param = "%%" + k + "%%"
             if wrapped_param in temp_url:
-                temp_url = temp_url.replace(wrapped_param, v)
+                temp_url = temp_url.replace(wrapped_param, str(v))
             else: raise UrlBadParam(self.base_url, k)
         return ApcUrl(temp_url)
 
@@ -97,10 +97,11 @@ class RequestProvider(object):
         # Now we must discover the possible actions
         actions = dict( (k,v) for k,v in cfg.iteritems() if '%%api_key%%' in v)
         for action_name, action_value in actions.iteritems():
-            new_url = self.url.params(action=action_value)
-            self.requests[action_name] = new_url
+            new_url = self.url.params(action=action_value).params(
+                api_key=self.config['api_key'])
+            self.requests[action_name] = ApiRequest(action_name, new_url)
 
-    def available_requests(self)    : return self.requests.keys
+    def available_requests(self)    : return self.requests.keys()
     def __contains__(self, request) : return request in self.requests
 
     def __getattr__(self, attr):

--- a/python_apps/api_clients/api_client.py
+++ b/python_apps/api_clients/api_client.py
@@ -69,7 +69,7 @@ class ApcUrl(object):
             if wrapped_param in temp_url:
                 temp_url = temp_url.replace(wrapped_param, v)
             else: raise UrlBadParam(self.base_url, k)
-            return ApcUrl(temp_url)
+        return ApcUrl(temp_url)
 
     def url(self):
         if '%%' in self.base_url: raise IncompleteUrl(self.base_url)

--- a/python_apps/api_clients/tests/test_apcurl.py
+++ b/python_apps/api_clients/tests/test_apcurl.py
@@ -1,0 +1,30 @@
+import unittest
+from .. api_client import ApcUrl, UrlBadParam, IncompleteUrl
+
+class TestApcUrl(unittest.TestCase):
+    def test_init(self):
+        url = "/testing"
+        u = ApcUrl(url)
+        self.assertEquals( u.base_url, url)
+
+    def test_params_1(self):
+        u = ApcUrl("/testing/%%key%%")
+        self.assertEquals(u.params(key='val').url(), '/testing/val')
+
+    def test_params_2(self):
+        u = ApcUrl('/testing/%%key%%/%%api%%/more_testing')
+        full_url = u.params(key="AAA",api="BBB").url()
+        self.assertEquals(full_url, '/testing/AAA/BBB/more_testing')
+
+    def test_params_ex(self):
+        u = ApcUrl("/testing/%%key%%")
+        with self.assertRaises(UrlBadParam):
+            u.params(bad_key='testing')
+
+    def test_url(self):
+        u = "one/two/three"
+        self.assertEquals( ApcUrl(u).url(), u )
+
+    def test_url_ex(self):
+        u = ApcUrl('/%%one%%/%%two%%/three').params(two='testing')
+        with self.assertRaises(IncompleteUrl): u.url()

--- a/python_apps/api_clients/tests/test_apirequest.py
+++ b/python_apps/api_clients/tests/test_apirequest.py
@@ -1,0 +1,7 @@
+import unittest
+from .. api_client import ApcUrl, ApiRequest
+
+class TestApiRequest(unittest.TestCase):
+    def test_init(self):
+        u = ApiRequest("request_name", ApcUrl("/test/ing"))
+        self.assertEquals(u.name, "request_name")

--- a/python_apps/api_clients/tests/test_apirequest.py
+++ b/python_apps/api_clients/tests/test_apirequest.py
@@ -1,7 +1,21 @@
 import unittest
+from mock import MagicMock, patch
 from .. api_client import ApcUrl, ApiRequest
 
 class TestApiRequest(unittest.TestCase):
     def test_init(self):
-        u = ApiRequest("request_name", ApcUrl("/test/ing"))
+        u = ApiRequest('request_name', ApcUrl('/test/ing'))
         self.assertEquals(u.name, "request_name")
+
+    def test_call(self):
+        ret = 'ok'
+        read = MagicMock()
+        read.read = MagicMock(return_value=ret)
+        u = '/testing'
+        with patch('urllib2.urlopen') as mock_method:
+            mock_method.return_value = read
+            request = ApiRequest('mm', ApcUrl(u))()
+            self.assertEquals(request, ret)
+            mock_method.assert_called_once_with(u)
+
+if __name__ == '__main__': unittest.main()

--- a/python_apps/api_clients/tests/test_requestprovider.py
+++ b/python_apps/api_clients/tests/test_requestprovider.py
@@ -1,0 +1,31 @@
+import unittest
+from mock import patch, MagicMock
+from configobj import ConfigObj
+from .. api_client import RequestProvider
+
+class TestRequestProvider(unittest.TestCase):
+    def setUp(self):
+        self.cfg = ConfigObj('api_client.cfg')
+    def test_test(self):
+        self.assertTrue('api_key' in self.cfg)
+    def test_init(self):
+        rp = RequestProvider(self.cfg)
+        self.assertTrue( len( rp.available_requests() ) > 0 )
+    def test_contains(self):
+        rp = RequestProvider(self.cfg)
+        methods = ['upload_recorded', 'update_media_url', 'list_all_db_files']
+        for meth in methods:
+            self.assertTrue( meth in rp )
+
+    def test_notify_webstream_data(self):
+        ret = 'testing'
+        rp = RequestProvider(self.cfg)
+        read = MagicMock()
+        read.read = MagicMock(return_value=ret)
+        with patch('urllib2.urlopen') as mock_method:
+            mock_method.return_value = read
+            response = rp.notify_webstream_data(media_id=123)
+            mock_method.called_once_with(media_id=123)
+            self.assertEquals(ret, response)
+
+if __name__ == '__main__': unittest.main()


### PR DESCRIPTION
First part of api_client refactoring. I've separated all the config and
url plumbing from api client itself into a separate class that's called
RequestProvider. This class isn't really for other modules to use, only
ApiClient itself. RequestProvider is initialized like so:

```
rp = RequestProvider(ConfigObj('api_client.cfg'))
```

Now rp automatically reads every api client method definitions so that you can
call actions defined in api_client.cfg like so:

```
response = rp.notify_webstream_data(media_id=123)
# the method above was automatically inferred from api_client.cfg
notify_webstream_data = 'notify-webstream-data/api_key/%%api_key%%/media_id/%%media_id%%/format/json'
```

Rewriting ApiClient using RequestProvider is going to shorten the code
quite a bit and get rid of all the boilerplate. This will also make
testing ApiClient very easy as well as all we'll have to do is to pass
a fake(mock) RequestProvider to ApiClient that will let introspect
ApiClient's behaviour. See for example tests/test_requiestprovider.py
