### PR TITLE
cc-4630: Added permission set on permission folder before watching it

### DIFF
--- a/utils/airtime-import/airtime-import.py
+++ b/utils/airtime-import/airtime-import.py
@@ -159,6 +159,7 @@ def WatchAddAction(option, opt, value, parser):
         path = currentDir+path
     path = apc.encode_to(path, 'utf-8')
     if(os.path.isdir(path)):
+        os.chmod(path, 0765)
         res = api_client.add_watched_dir(path)
         if(res is None):
             exit("Unable to connect to the server.")


### PR DESCRIPTION
This has been broken for a long time. So airtime-import must not have been used very often. The fix is very simple. Just set the correct permissions for the directory.
