### PR TITLE
Saas touch file

### DIFF
--- a/python_apps/media-monitor2/media/saas/airtimeinstance.py
+++ b/python_apps/media-monitor2/media/saas/airtimeinstance.py
@@ -41,7 +41,7 @@ class AirtimeInstance(object):
 
     def touch_file_path(self):
         """ Get the path of the touch file for every instance """
-        touch_base_path = self.mm_config['index-path']
+        touch_base_path = self.mm_config['index_path']
         touch_base_name = basename(touch_base_path)
         new_base_name   = self.name + touch_base_name
         return join(dirname(touch_base_path), new_base_name)

--- a/python_apps/media-monitor2/media/saas/airtimeinstance.py
+++ b/python_apps/media-monitor2/media/saas/airtimeinstance.py
@@ -1,5 +1,5 @@
 import os
-from os.path import join
+from os.path import join, basename, dirname
 
 from media.monitor.exceptions import NoConfigFile
 from media.monitor.pure import LazyProperty
@@ -38,6 +38,14 @@ class AirtimeInstance(object):
     def signal(self, sig):
         if isinstance(sig, SignalString): return sig
         else: return SignalString("%s_%s" % (self.name, sig))
+
+    def touch_file_path(self):
+        """ Get the path of the touch file for every instance """
+        touch_base_path = self.mm_config['index-path']
+        touch_base_name = basename(touch_base_path)
+        new_base_name   = self.name + touch_base_name
+        return join(dirname(touch_base_path), new_base_name)
+        
 
     def __str__(self):
         return "%s,%s(%s)" % (self.name, self.root_path, self.config_paths)

--- a/python_apps/media-monitor2/media/saas/launcher.py
+++ b/python_apps/media-monitor2/media/saas/launcher.py
@@ -44,9 +44,9 @@ class MM2(InstanceThread, Loggable):
         manager = Manager()
         apiclient = apc()
         config = user().mm_config
-        watch_syncer = WatchSyncer(signal=getsig('watch'),
-                                   chunking_number=config['chunking_number'],
-                                   timeout=config['request_max_wait'])
+        WatchSyncer(signal=getsig('watch'),
+                chunking_number=config['chunking_number'],
+                timeout=config['request_max_wait'])
         airtime_receiver = AirtimeMessageReceiver(config,manager)
         airtime_notifier = AirtimeNotifier(config, airtime_receiver)
 
@@ -75,15 +75,15 @@ class MM2(InstanceThread, Loggable):
                 airtime_receiver.new_watch({ 'directory':watch_dir }, restart=True)
             else: self.logger.info("Failed to add watch on %s" % str(watch_dir))
 
-        ed = EventDrainer(airtime_notifier.connection,
+        EventDrainer(airtime_notifier.connection,
                 interval=float(config['rmq_event_wait']))
 
         # Launch the toucher that updates the last time when the script was
         # ran every n seconds.
         # TODO : verify that this does not interfere with bootstrapping because the
         # toucher thread might update the last_ran variable too fast
-        tt = ToucherThread(path=config['index_path'],
-                           interval=int(config['touch_interval']))
+        ToucherThread(path=user().touch_file_path(),
+                interval=int(config['touch_interval']))
 
         apiclient.register_component('media-monitor')
 


### PR DESCRIPTION
Fixed the saas touch file stuff. Now we prepend the airtime instances name to the touch file.
One thing to think keep in mind is that we should make sure that there are no slashes or newlines in the AirtimeInstance#name fields. Otherwise this mechanism will fail.
