### PR TITLE
Update airtime_mvc/public/js/airtime/preferences/streamsetting.js

### DIFF
--- a/airtime_mvc/public/js/airtime/preferences/streamsetting.js
+++ b/airtime_mvc/public/js/airtime/preferences/streamsetting.js
@@ -39,8 +39,8 @@ function restrictOggBitrate(ele, on){
         div.find("select[id$=data-bitrate]").find("option[value='24']").attr("disabled","disabled");
         div.find("select[id$=data-bitrate]").find("option[value='32']").attr("disabled","disabled");
     }else{
-        div.find("select[id$=data-bitrate]").find("option[value='24']").attr("disabled","");
-        div.find("select[id$=data-bitrate]").find("option[value='32']").attr("disabled","");
+    	div.find("select[id$=data-bitrate]").find("option[value='24']").removeAttr("disabled");
+        div.find("select[id$=data-bitrate]").find("option[value='32']").removeAttr("disabled");
     }
 }
 function hideForShoutcast(ele){


### PR DESCRIPTION
Update statement to remove "disabled" attribute to be compatible with chrome and firefox browser.

Based on my experience.
