### PR TITLE
Saas broken unit tests schedule messed up

### DIFF
--- a/airtime_mvc/application/models/airtime/CcShow.php
+++ b/airtime_mvc/application/models/airtime/CcShow.php
@@ -295,24 +295,6 @@ class CcShow extends BaseCcShow {
         }
         return $instanceIds;
     }
-    
-    /*
-     * Returns all show instances ordered by 'starts' column in desc order.
-     */
-    public function getInstanceIdsSortedByMostRecentStartTime()
-    {
-        $instances = CcShowInstancesQuery::create()
-            ->filterByCcShow($this)
-            ->filterByDbModifiedInstance(false)
-            ->orderByDbStarts(Criteria::DESC)
-            ->find();
-            
-        $instanceIdsDescOrder = array();
-        foreach ($instances as $instance) {
-            $instanceIdsDescOrder[] = $instance->getDbId();
-        }
-        return $instanceIdsDescOrder;
-    }
 
     //what is this??
     public function getOtherInstances($instanceId)

--- a/airtime_mvc/application/models/airtime/CcShow.php
+++ b/airtime_mvc/application/models/airtime/CcShow.php
@@ -281,9 +281,16 @@ class CcShow extends BaseCcShow {
         return $instanceIds;
     }
     
-    public function getFutureInstanceIds() {
+    /*
+     * Returns cc_show_instance ids where the start time is greater than
+     * the current time
+     * 
+     * If a Criteria object is passed in Propel will always fetch the 
+     * results from the database and not return a cached collection
+     */
+    public function getFutureInstanceIds($criteria = null) {
         $instanceIds = array();
-        foreach ($this->getFutureCcShowInstancess() as $ccShowInstance) {
+        foreach ($this->getFutureCcShowInstancess($criteria) as $ccShowInstance) {
             $instanceIds[] = $ccShowInstance->getDbId();
         }
         return $instanceIds;

--- a/airtime_mvc/application/services/SchedulerService.php
+++ b/airtime_mvc/application/services/SchedulerService.php
@@ -207,40 +207,6 @@ class Application_Service_SchedulerService
      */
     public static function fillLinkedInstances($ccShow, $instanceIdsToFill, $instanceId=null)
     {
-        //TODO can we remove the code until line 216 ??
-        
-        /*
-        $instanceIds = $ccShow->getInstanceIdsSortedByMostRecentStartTime();
-        if (count($instanceIds) == 0) {
-            return;
-        }
-
-       //First check if any linked instances have content
-       //If all instances are empty then we don't need to fill
-       //any other instances with content
-       $doesAnyShowInstanceHaveContent = false;
-       foreach ($instanceIds as $instanceId)
-       {
-            $schedule_sql = "SELECT instance_id FROM cc_schedule ".
-                "WHERE instance_id=$instanceId";//#IN (".implode($instanceIds, ",").")";
-            $ccSchedules = Application_Common_Database::prepareAndExecute(
-                $schedule_sql);
-            if (count($ccSchedules) > 0) {
-                $doesAnyShowInstanceHaveContent = true;
-                break;
-            }
-       }
-       //variable out of scope outside foreach loop
-       unset($ccSchedules);
-
-       if ($doesAnyShowInstanceHaveContent == false)
-       {
-            //The linked shows are all empty, so there's nothing for us to do.
-            //(No content should be propagated to the other show instances...
-            return;
-       }
-       */
-
         //Get the "template" schedule for the linked show (contents of the linked show) that will be 
         //copied into to all the new show instances.
         $linkedShowSchedule = self::getLinkedShowSchedule($ccShow->getDbId(), $instanceIdsToFill, $instanceId);

--- a/airtime_mvc/application/services/SchedulerService.php
+++ b/airtime_mvc/application/services/SchedulerService.php
@@ -182,15 +182,7 @@ class Application_Service_SchedulerService
      */
     public static function fillNewLinkedInstances($ccShow, $instanceIdsToFill)
     {
-        /* In order to get the linked show's schedule we need to retrieve
-         * every instance of the show, even if they are in the past in case
-         * no new instances were generated past the 'shows_populated_until'
-         * date in cc_pref - CC-5898
-         * 
-         * We retrieve the instances ids sorted by desc start date to ensure
-         * we always use the most up to date schedule when filling the new
-         * show instances with content
-         */
+        //TODO can we remove the code until line 216 ??
         
         $instanceIds = $ccShow->getInstanceIdsSortedByMostRecentStartTime();
         if (count($instanceIds) == 0) {
@@ -221,7 +213,7 @@ class Application_Service_SchedulerService
             //The linked shows are all empty, so there's nothing for us to do.
             //(No content should be propagated to the other show instances...
             return;
-       }               
+       }
 
         $linkedShowSchedule = self::getLinkedShowSchedule($ccShow->getDbId(), $instanceIdsToFill);
 

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -277,7 +277,7 @@ function setAddShowEvents(form) {
         //only display the warning message if a show is being edited
         if ($(".button-bar.bottom").find(".ui-button-text").text() === "Update show") {
             if ($(this).attr("checked") && $("#show-link-warning").length === 0) {
-                $(this).parent().after("<ul id='show-link-warning' class='errors'><li>"+$.i18n._("Warning: A copy of the schedule from the show clicked on to edit this show will get copied to every other show in the repeat series.")+"</li></ul>");
+                $(this).parent().after("<ul id='show-link-warning' class='errors'><li>"+$.i18n._("Warning: All other repetitions of this show will have their contents replaced to match the show you selected 'Edit Show' with.")+"</li></ul>");
             }
             
             if (!$(this).attr("checked") && $("#show-link-warning").length !== 0) {

--- a/airtime_mvc/public/js/airtime/schedule/add-show.js
+++ b/airtime_mvc/public/js/airtime/schedule/add-show.js
@@ -273,9 +273,16 @@ function setAddShowEvents(form) {
             }
             return false;
         }
-
-        if (!$(this).attr("checked") && $("#show-link-warning").length === 0) {
-            $(this).parent().after("<ul id='show-link-warning' class='errors'><li>"+$.i18n._("Warning: Shows cannot be re-linked")+"</li></ul>");
+        
+        //only display the warning message if a show is being edited
+        if ($(".button-bar.bottom").find(".ui-button-text").text() === "Update show") {
+            if ($(this).attr("checked") && $("#show-link-warning").length === 0) {
+                $(this).parent().after("<ul id='show-link-warning' class='errors'><li>"+$.i18n._("Warning: A copy of the schedule from the show clicked on to edit this show will get copied to every other show in the repeat series.")+"</li></ul>");
+            }
+            
+            if (!$(this).attr("checked") && $("#show-link-warning").length !== 0) {
+                $("#show-link-warning").remove();
+            }
         }
     });
 

--- a/airtime_mvc/tests/application/services/database/ShowServiceDbTest.php
+++ b/airtime_mvc/tests/application/services/database/ShowServiceDbTest.php
@@ -442,26 +442,6 @@ class ShowServiceDbTest extends Zend_Test_PHPUnit_DatabaseTestCase
             $this->createXmlDataSet(dirname(__FILE__)."/datasets/test_createLinkedShow.xml"),
         $ds
         );
-
-        /** Test unlinking a show **/
-        $data["add_show_id"] = 1;
-        $data["add_show_linked"] = 0;
-        $showService = new Application_Service_ShowService(null, $data, true);
-        $showService->addUpdateShow($data);
-
-        $ds = new Zend_Test_PHPUnit_Db_DataSet_QueryDataSet(
-            $this->getConnection()
-        );
-        $ds->addTable('cc_show', 'select * from cc_show');
-        $ds->addTable('cc_show_days', 'select * from cc_show_days');
-        $ds->addTable('cc_show_instances', 'select id, starts, ends, show_id, record, rebroadcast, instance_id, modified_instance from cc_show_instances order by id');
-        $ds->addTable('cc_show_rebroadcast', 'select * from cc_show_rebroadcast');
-        $ds->addTable('cc_show_hosts', 'select * from cc_show_hosts');
-
-        $this->assertDataSetsEqual(
-            $this->createXmlDataSet(dirname(__FILE__)."/datasets/test_unlinkLinkedShow.xml"),
-            $ds
-        );
     }
 
     /** Test the creation of a single record and rebroadcast(RR) show **/


### PR DESCRIPTION
Unit tests all pass now. They were failing because propel was returning a cached object collection.

Optimized the filling of linked show instances schedules:
When new show instances are created, we store their id in an associated array, organized by their cc_show id. This array gets passed to the fillNewLinkedInstances function and thus the guess work to determine which instances need their schedules filled is gone.
