### PR TITLE
PHP ini settings for cookies.

### DIFF
--- a/airtime_mvc/public/index.php
+++ b/airtime_mvc/public/index.php
@@ -1,5 +1,15 @@
 <?php
 
+//  Only enable cookie secure if we are supporting https.
+//  Ideally, this would always be on and we would force https,
+//  but the default installation configs are likely to be installed by
+//  amature users on the setup that does not have https.  Forcing
+//  cookie_secure on non https would result in confusing login problems.
+if(!empty($_SERVER['HTTPS'])){
+        ini_set('session.cookie_secure', '1');
+}
+ini_set('session.cookie_httponly', '1');
+
 error_reporting(E_ALL|E_STRICT);
 
 function exception_error_handler($errno, $errstr, $errfile, $errline)


### PR DESCRIPTION
I attempted to do this in a way that plays nicely with the Zend frame work using

Zend_Session::setOptions(array('cookie_secure' => true));

but I was unsuccessful in getting the change to actually take effect.  If you know of a better way to do this, or a better place for this code to live, let me know.
