### PR TITLE
More tokens

### DIFF
--- a/airtime_mvc/application/controllers/PluploadController.php
+++ b/airtime_mvc/application/controllers/PluploadController.php
@@ -24,15 +24,33 @@ class PluploadController extends Zend_Controller_Action
         $this->view->headScript()->appendFile($baseUrl.'js/plupload/i18n/'.$locale.'.js?'.$CC_CONFIG['airtime_version'],'text/javascript');
 
         $this->view->headLink()->appendStylesheet($baseUrl.'css/plupload.queue.css?'.$CC_CONFIG['airtime_version']);
+
+        $csrf_namespace = new Zend_Session_Namespace('csrf_namespace');
+        $csrf_namespace->setExpirationSeconds(900);
+        $csrf_namespace->authtoken = sha1(uniqid(rand(),1));
+
+        $csrf_element = new Zend_Form_Element_Hidden('csrf');
+        $csrf_element->setValue($csrf_namespace->authtoken)->setRequired('true')->removeDecorator('HtmlTag')->removeDecorator('Label');
+        $csrf_form = new Zend_Form();
+        $csrf_form->addElement($csrf_element);
+        $this->view->form = $csrf_form;
     }
 
     public function uploadAction()
     {
-        $upload_dir = ini_get("upload_tmp_dir") . DIRECTORY_SEPARATOR . "plupload";
-        $tempFilePath = Application_Model_StoredFile::uploadFile($upload_dir);
-        $tempFileName = basename($tempFilePath);
+        $current_namespace = new Zend_Session_Namespace('csrf_namespace');
+        $observed_csrf_token = $this->_getParam('csrf_token');
+        $expected_csrf_token = $current_namespace->authtoken;
 
-        $this->_helper->json->sendJson(array("jsonrpc" => "2.0", "tempfilepath" => $tempFileName));
+        if($observed_csrf_token == $expected_csrf_token){
+            $upload_dir = ini_get("upload_tmp_dir") . DIRECTORY_SEPARATOR . "plupload";
+            $tempFilePath = Application_Model_StoredFile::uploadFile($upload_dir);
+            $tempFileName = basename($tempFilePath);
+         
+            $this->_helper->json->sendJson(array("jsonrpc" => "2.0", "tempfilepath" => $tempFileName));
+        }else{
+            $this->_helper->json->sendJson(array("jsonrpc" => "2.0", "valid" => false, "error" => "CSRF token did not match."));
+        }
     }
 
     public function copyfileAction()

--- a/airtime_mvc/application/controllers/PluploadController.php
+++ b/airtime_mvc/application/controllers/PluploadController.php
@@ -26,7 +26,7 @@ class PluploadController extends Zend_Controller_Action
         $this->view->headLink()->appendStylesheet($baseUrl.'css/plupload.queue.css?'.$CC_CONFIG['airtime_version']);
 
         $csrf_namespace = new Zend_Session_Namespace('csrf_namespace');
-        $csrf_namespace->setExpirationSeconds(900);
+        $csrf_namespace->setExpirationSeconds(5*60*60);
         $csrf_namespace->authtoken = sha1(uniqid(rand(),1));
 
         $csrf_element = new Zend_Form_Element_Hidden('csrf');

--- a/airtime_mvc/application/controllers/PreferenceController.php
+++ b/airtime_mvc/application/controllers/PreferenceController.php
@@ -201,6 +201,10 @@ class PreferenceController extends Zend_Controller_Action
         $num_of_stream = intval(Application_Model_Preference::GetNumOfStreams());
         $form = new Application_Form_StreamSetting();
 
+        $form->addElement('hash', 'csrf', array(
+           'salt' => 'unique'
+        ));
+
         $form->setSetting($setting);
         $form->startFrom();
 

--- a/airtime_mvc/application/forms/AddUser.php
+++ b/airtime_mvc/application/forms/AddUser.php
@@ -21,6 +21,10 @@ class Application_Form_AddUser extends Zend_Form
         $hidden->setDecorators(array('ViewHelper'));
         $this->addElement($hidden);
 
+        $this->addElement('hash', 'csrf', array(
+           'salt' => 'unique'
+        ));
+
         $login = new Zend_Form_Element_Text('login');
         $login->setLabel(_('Username:'));
         $login->setAttrib('class', 'input_text');

--- a/airtime_mvc/application/forms/Preferences.php
+++ b/airtime_mvc/application/forms/Preferences.php
@@ -15,6 +15,14 @@ class Application_Form_Preferences extends Zend_Form
         ));
 
         $general_pref = new Application_Form_GeneralPreferences();
+
+        $this->addElement('hash', 'csrf', array(
+           'salt' => 'unique',
+           'decorators' => array(
+                'ViewHelper'
+            )
+        ));
+
         $this->addSubForm($general_pref, 'preferences_general');
 
             $email_pref = new Application_Form_EmailServerPreferences();

--- a/airtime_mvc/application/views/scripts/form/preferences.phtml
+++ b/airtime_mvc/application/views/scripts/form/preferences.phtml
@@ -1,5 +1,5 @@
 <form method="<?php echo $this->element->getMethod() ?>" enctype="multipart/form-data">
-
+    <?php echo $this->element->getElement('csrf') ?>
     <?php echo $this->element->getSubform('preferences_general') ?>
     
     <h3 class="collapsible-header" id="email-server-heading"><span class="arrow-icon"></span><?php echo _("Email / Mail Server Settings"); ?></h3>

--- a/airtime_mvc/application/views/scripts/plupload/index.phtml
+++ b/airtime_mvc/application/views/scripts/plupload/index.phtml
@@ -4,6 +4,7 @@
 }
 </style> 
 <form id="plupload_form">
+        <?php echo $this->form->getElement('csrf') ?>
 	<div id="plupload_files"></div>	
 </form>
 <div id="plupload_error">

--- a/airtime_mvc/application/views/scripts/preference/stream-setting.phtml
+++ b/airtime_mvc/application/views/scripts/preference/stream-setting.phtml
@@ -4,6 +4,7 @@
     <?php if($this->enable_stream_conf == "true"){?>
     <form method="post" id="stream_form" enctype="application/x-www-form-urlencoded">
     <button name="stream_save" id="stream_save" type="button" class="btn btn-small right-floated"><?php echo _("Save") ?></button>
+    <?php echo $this->form->getElement('csrf') ?>
     <div style="clear:both"></div>
     <?php }?>
   <?php echo $this->statusMsg;?>

--- a/airtime_mvc/public/js/airtime/library/plupload.js
+++ b/airtime_mvc/public/js/airtime/library/plupload.js
@@ -11,7 +11,10 @@ $(document).ready(function() {
 		multiple_queues : 'true',
 		filters : [
 			{title: "Audio Files", extensions: "ogg,mp3,oga,flac,wav,m4a,mp4,opus"}
-		]
+		],
+                multipart_params : {
+                    "csrf_token" : $("#csrf").attr('value'),
+                }
 	});
 
 	uploader = $("#plupload_files").pluploadQueue();


### PR DESCRIPTION
More csrf tokens for various forms in Airtime, including the multi-part file upload.  I was able to test all of these, but for the multi-part file upload I was never able to see the library enter the list of things in media.  I believe this is an unrelated problem because it seems to happen even without my code change.  The ajax requests for multi-part file upload appear to work (from what I can see in the network manager in chrome developer), but the files not appearing bug interferers with my ability to completely verify this bug fix.
