### PR TITLE
Disable exit on error when checking if apache2.4 is installed.

### DIFF
--- a/install_full/ubuntu/airtime-full-install
+++ b/install_full/ubuntu/airtime-full-install
@@ -29,8 +29,10 @@ echo "----------------------------------------------------"
 
 dist=`lsb_release -is`
 code=`lsb_release -cs`
+set +e
 apache2 -v | grep "2\.4" > /dev/null
 apacheversion=$?
+set -e
 
 #enable squeeze backports to get lame packages
 if [ "$dist" = "Debian" -a "$code" = "squeeze" ]; then


### PR DESCRIPTION
This fix is not ideal, and there is likely a better way to do the version detection, but it should work for now.
