### PR TITLE
Saas relder csrf delete file

### DIFF
--- a/airtime_mvc/application/modules/rest/controllers/MediaController.php
+++ b/airtime_mvc/application/modules/rest/controllers/MediaController.php
@@ -129,15 +129,6 @@ class Rest_MediaController extends Zend_Rest_Controller
     
     public function postAction()
     {
-        /*  If the user presents a valid API key, we don't check CSRF tokens.  
-            CSRF tokens are only used for session based authentication.
-        */
-        if(!$this->verifyAPIKey()){
-            if(!$this->verifyCSRFToken($this->_getParam('csrf_token'))){
-                return;
-            }
-        }
-
         if (!$this->verifyAuth(true, true))
         {
             return;
@@ -304,26 +295,17 @@ class Rest_MediaController extends Zend_Rest_Controller
         return $id;
     }
 
-    private function verifyCSRFToken($token){
-        $current_namespace = new Zend_Session_Namespace('csrf_namespace');
-        $observed_csrf_token = $token;
-        $expected_csrf_token = $current_namespace->authtoken;
-
-        if($observed_csrf_token == $expected_csrf_token){
-            return true;
-        }else{
-            $resp = $this->getResponse();
-            $resp->setHttpResponseCode(401);
-            $resp->appendBody("ERROR: Token Missmatch."); 
-            return false;
-        }
-    }
-    
     private function verifyAuth($checkApiKey, $checkSession)
     {
-        //Session takes precedence over API key for now:
-        if ($checkSession && $this->verifySession()) 
-        {
+        //  Session takes precedence over API key for now:
+        if ($checkSession && $this->verifySession()) {
+            //  CSRF token validation only applies to session based authorization.
+            if(!$this->verifyCSRFToken($this->_getParam('csrf_token'))){
+                $resp = $this->getResponse();
+                $resp->setHttpResponseCode(401);
+                $resp->appendBody("ERROR: Token Missmatch."); 
+                return false;
+            }
             return true;
         }
         
@@ -339,6 +321,17 @@ class Rest_MediaController extends Zend_Rest_Controller
         return false;
     }
     
+    private function verifyCSRFToken($token){
+        $current_namespace = new Zend_Session_Namespace('csrf_namespace');
+        $observed_csrf_token = $token;
+        $expected_csrf_token = $current_namespace->authtoken;
+
+        if($observed_csrf_token == $expected_csrf_token){
+            return true;
+        }else{
+            return false;
+        }
+    }
 
     private function verifyAPIKey()
     {

--- a/airtime_mvc/public/js/airtime/library/plupload.js
+++ b/airtime_mvc/public/js/airtime/library/plupload.js
@@ -89,7 +89,7 @@ $(document).ready(function() {
     	
     	$.ajax({
     		  type: 'DELETE',
-    		  url: '/rest/media/' + file.id,
+    		  url: 'rest/media/' + file.id + "?csrf_token=" + $("#csrf").attr('value'),
     		  success: function(resp) {
     			  self.recentUploadsTable.fnDraw();
     		  },

--- a/airtime_mvc/public/js/airtime/library/plupload.js
+++ b/airtime_mvc/public/js/airtime/library/plupload.js
@@ -89,7 +89,7 @@ $(document).ready(function() {
     	
     	$.ajax({
     		  type: 'DELETE',
-    		  url: 'rest/media/' + file.id + "?csrf_token=" + $("#csrf").attr('value'),
+    		  url: baseUrl + 'rest/media/' + file.id + "?csrf_token=" + $("#csrf").attr('value'),
     		  success: function(resp) {
     			  self.recentUploadsTable.fnDraw();
     		  },


### PR DESCRIPTION
A bit of refactoring to build CSRF verification into all routes in /rest/media.  To my knowledge, we're only using session based authentication in the delete and upload routes currently (there are a number of others).

I also added a prefix of baseUrl to the url because our other branch adds baseDir for this API call.  I'm not sure if baseUrl and baseDir are interchangable, but baseDir is not defined here.  Tested with deletion and it works.
