### PR TITLE
Ubuntu: Add Media now upload files into Library

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -102,11 +102,11 @@ case "$1" in
 
       # PHP config
       echo "Configuring php5..."
-      if [ ! -d /etc/$php/conf.d/ ]; then
-        install -d -m755 /etc/$php/conf.d/
+      if [ ! -d /etc/$php/$webserver/conf.d/ ]; then
+        install -d -m755 /etc/$php/$webserver/conf.d/
       fi
-      if [ ! -e /etc/$php/conf.d/airtime.ini ]; then
-        ln -s ${phpinifile} /etc/$php/conf.d/airtime.ini
+      if [ ! -e /etc/$php/$webserver/conf.d/airtime.ini ]; then
+        ln -s ${phpinifile} /etc/$php/$webserver/conf.d/airtime.ini
       fi
 
       # restart apache


### PR DESCRIPTION
With a fresh install of **Ubuntu 14.04.1 LTS Trusty** and **Airtime 2.5.1-5**, the `Add Media` feature silently fails because the /etc/airtime/airtime.ini file is not parsed by Apache PHP. And the file of course does not appear in the `Library`.

While with Debian (at least on my **7.7 Wheezy**) `libapache2-mod-php5` package, the path `/etc/php5/apache2/conf.d` is just a symlink to `/etc/php5/conf.d`, it seems that with Ubuntu's `libapache2-mod-php5` it's a real folder on its own.

Therefore, current installation of Airtime on Ubuntu 14.04 and 13.10 seems to get an `Add Media` feature which silently fails, as noted by Stefan here: https://forum.sourcefabric.org/discussion/comment/27548#Comment_27548

A way to fix this (which should work both for Debian and Ubuntu) is to directly create the `airtime.ini` symlink into `/etc/php5/apache2/conf.d`, as suggested in the pull request.
