### PR TITLE
Airtime-liquidsoap should start before Apache

### DIFF
--- a/python_apps/pypo/install/pypo-initialize.py
+++ b/python_apps/pypo/install/pypo-initialize.py
@@ -80,7 +80,7 @@ try:
 
     #initialize init.d scripts
     subprocess.call("update-rc.d airtime-playout defaults >/dev/null 2>&1", shell=True)
-    subprocess.call("update-rc.d airtime-liquidsoap defaults >/dev/null 2>&1", shell=True)
+    subprocess.call("update-rc.d airtime-liquidsoap defaults 92 8 >/dev/null 2>&1", shell=True)
 
     #clear out an previous pypo cache
     print "* Clearing previous pypo cache"


### PR DESCRIPTION
When launched, Liquidsoap tries to connect to Airtime API, served by Apache. Because rc2.d script `apache2` is started **S91** after `airtime-liquidsoap` **S20**, it fails at each boots of Ubuntu. But thanks to `monit` **S99**, `airtime-liquidsoap` is soon relaunched and the first failure is not noticed (except for a sensible longer boot time).

Typically, it's shown as this in boot messages displayed on the console:

```
Starting Liquidsoap Playout Engine: Unable to connect to the Airtime server.
<urlopen error [Errno 111] Connection refused>
traceback: Traceback (most recent call last):
  File "generate_liquidsoap_cfg.py", line 37, in <module>
    ss = ac.get_stream_setting()
  File "/usr/lib/airtime/api_clients/api_client.py", line 414, in get_stream_setting
    return self.services.get_stream_setting()
  File "/usr/lib/airtime/api_clients/api_client.py", line 137, in __call__
    f = urllib2.urlopen(req)
  File "/usr/lib/python2.7/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 400, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 418, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 378, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1207, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1177, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 111] Connection refused>
```

But it should start right from the first try. ;-)

Current status:

``` bash
# Start
/etc/rc2.d/S20airtime-liquidsoap
/etc/rc2.d/S20airtime-media-monitor
/etc/rc2.d/S20airtime-playout
/etc/rc2.d/S91apache2
/etc/rc2.d/S99monit
# Stop
/etc/rc0.d/K01monit
/etc/rc0.d/K09apache2
/etc/rc0.d/K20airtime-liquidsoap
/etc/rc0.d/K20airtime-media-monitor
/etc/rc0.d/K20airtime-playout
```

Suggested :

``` bash
# Start
/etc/rc2.d/S20airtime-media-monitor
/etc/rc2.d/S20airtime-playout
/etc/rc2.d/S91apache2
/etc/rc2.d/S92airtime-liquidsoap
/etc/rc2.d/S99monit
# Stop
/etc/rc0.d/K01monit
/etc/rc0.d/K08airtime-liquidsoap
/etc/rc0.d/K09apache2
/etc/rc0.d/K20airtime-media-monitor
/etc/rc0.d/K20airtime-playout
```

Note: Maybe there is the same kind of problem for Media-Monitor and Playout, but I didn't noticed anything yet.
