### PR TITLE
Debian/Ubuntu require a force-reload option for sysvinit scripts

### DIFF
--- a/python_apps/media-monitor/install/sysvinit/airtime-media-monitor
+++ b/python_apps/media-monitor/install/sysvinit/airtime-media-monitor
@@ -61,6 +61,13 @@ case "${1:-''}" in
            start
            echo "Done."
         ;;
+  'force-reload')
+           # reload commands here
+           echo -n "Reloading $NAME: "
+           stop
+           start
+           echo "Done."
+        ;;
   'status')
 	   status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;

--- a/python_apps/pypo/install/sysvinit/airtime-liquidsoap
+++ b/python_apps/pypo/install/sysvinit/airtime-liquidsoap
@@ -61,6 +61,13 @@ case "${1:-''}" in
            start
            echo "Done."
         ;;
+  'force-reload')
+           # reload commands here
+           echo -n "Reloading $NAME: "
+           stop
+           start
+           echo "Done."
+        ;;
   'status')
 	   status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;

--- a/python_apps/pypo/install/sysvinit/airtime-playout
+++ b/python_apps/pypo/install/sysvinit/airtime-playout
@@ -61,6 +61,13 @@ case "${1:-''}" in
            start
            echo "Done."
         ;;
+  'force-reload')
+           # reload commands here
+           echo -n "Reloading $NAME: "
+           stop
+           start
+           echo "Done."
+        ;;
   'status')
 	   status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;


### PR DESCRIPTION
Please see https://www.debian.org/doc/debian-policy/ch-opersys.html#s-writing-init

The force-reload option has the same effect as the existing restart option in these three cases, but package building tool Lintian throws an error if the force-reload option is not available to users.
