### PR TITLE
Add missing argument to playlistNotFound call

### DIFF
--- a/airtime_mvc/application/controllers/PlaylistController.php
+++ b/airtime_mvc/application/controllers/PlaylistController.php
@@ -200,7 +200,7 @@ class PlaylistController extends Zend_Controller_Action
             $obj = new $objInfo['className']($id);
             $this->createFullResponse($obj);
         } catch (PlaylistNotFoundException $e) {
-            $this->playlistNotFound();
+            $this->playlistNotFound($type);
         } catch (Exception $e) {
             $this->playlistUnknownError($e);
         }


### PR DESCRIPTION
Fixes a rather small bug that was probably only visible in the logs to start with.
