### PR TITLE
Split is deprecated PHP>5.3. Replace 'split' to 'explode' or 'preg_split'

### DIFF
--- a/airtime_mvc/library/phing/tasks/ext/coverage/CoverageReportTask.php
+++ b/airtime_mvc/library/phing/tasks/ext/coverage/CoverageReportTask.php
@@ -238,7 +238,7 @@ class CoverageReportTask extends Task
 
             $html = $geshi->parse_code();
 
-            $lines = split("<li>|</li>", $html);
+            $lines = preg_split("/<li>|<\/li>/", $html);
 
             // skip first and last line
             array_pop($lines);

--- a/airtime_mvc/library/phing/tasks/ext/phk/PhkPackageTask.php
+++ b/airtime_mvc/library/phing/tasks/ext/phk/PhkPackageTask.php
@@ -224,7 +224,7 @@ class PhkPackageTask extends Task
          * Print with Phing log...
          */
         $output = trim(ob_get_clean());
-        $output = split("\n", $output);
+        $output = explode("\n", $output);
         foreach ($output as $line) {
             /*
              * Delete all '--- *' lines. Bluh!


### PR DESCRIPTION
Split is deprecated PHP>5.3. Replace 'split' to 'explode' or 'preg_split' for PHP 7
