### PR TITLE
Display fork information on about page

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -80,3 +80,7 @@ define('UI_BLOCK_SESSNAME', 'BLOCK');*/
 define('SOUNDCLOUD_NOT_UPLOADED_YET' , -1);
 define('SOUNDCLOUD_PROGRESS'         , -2);
 define('SOUNDCLOUD_ERROR'            , -3);
+
+if (is_readable(__DIR__ . '/constants.fork.php')) {
+    include __DIR__ . '/constants.fork.php';
+}

--- a/airtime_mvc/application/controllers/DashboardController.php
+++ b/airtime_mvc/application/controllers/DashboardController.php
@@ -115,6 +115,8 @@ class DashboardController extends Zend_Controller_Action
     public function aboutAction()
     {
         $this->view->airtime_version = Application_Model_Preference::GetAirtimeVersion();
+
+        $this->view->is_fork = defined('AIRTIME_FORK_NAME');
     }
 
 }

--- a/airtime_mvc/application/views/scripts/dashboard/about.phtml
+++ b/airtime_mvc/application/views/scripts/dashboard/about.phtml
@@ -11,6 +11,15 @@ echo sprintf(_('%1$s %2$s, the open radio software for scheduling and remote sta
     $this->airtime_version)
 ?>
 <br />
+<?php 
+if ($this->is_fork) {
+$forkAnchor = '<a href="' . AIRTIME_FORK_URL . '" target="_blank">'
+                 . AIRTIME_FORK_NAME
+             . '</a>'; 
+echo sprintf('%1$s %2$s, %3$s<br />',
+    $forkAnchor, AIRTIME_FORK_VERSION, AIRTIME_FORK_DESCRIPTION);
+}
+?>
 <br />© 2013 
 <?php 
 $companySiteAnchor = "<a href='" . COMPANY_SITE_URL . "' target='_blank'>"

--- a/docs/README.forking.md
+++ b/docs/README.forking.md
@@ -1,0 +1,41 @@
+# Information on Forking this Repository
+
+Some work has been put into making this easier to fork. Due to the nature of the
+AGPL, forking is more or less mandated as we need to contribute our changes. The
+lack of a merging upstream has led to a situation where a lot of forks exist
+in a competing space. The forking support was implemented by [Radio Bern Rabe](http://rabe.ch)
+as part of the [RaBe Airtime Fork](https://github.com/radiorabe/airtime) to 
+help in testing various forks. It makes it easy to customize a fork to a degree
+where we can recognize the difference between a fork and upstream.
+
+We plan on adding more features to the fork detection as the need arises.
+
+The places where Airtime displays version and application name information
+are at the beginning of the installer as well as in the about page.
+
+At the moment the installer does not get overridden since we have no interest
+in it. This would be easy to implement though.
+
+## Configuration
+
+You can configure your fork by creating the file `airtime_mvc/application/configs/constants.fork.php`
+and defining constants.
+
+```php
+<?php
+define('AIRTIME_FORK_VERSION', '0.0.0');
+define('AIRTIME_FORK_NAME', 'Airtime Fork');
+define('AIRTIME_FORK_URL', 'https://github.com/<your-username>/airtime');
+define('AIRTIME_FORK_DESCRIPTION', 'fork feature blurb for about page');
+```
+
+You need to define all of the above constants or the feature will trigger notice errors
+and the about page will 404 on you.
+
+## About Page
+
+The about page on `/dashboard/about` will now display the following additional line.
+
+```
+<a href="AIRTIME_FORK_URL">AIRTIME_FORK_NAME</a> AIRTIME_FORK_VERSION, AIRTIME_FORK_DESCRIPTION
+```


### PR DESCRIPTION
This feature allows displaying information about a fork on /dashboard/about. It was
developed in a way to minimize the changes needed by a potential downstream user. 

It is inspired by https://github.com/rakutentech/airtime/commit/ec6e5f5dbb1909f8569db6baea93642ae8259c3b
which triggered an urge to scratch this particular itch. I have been thinking about something
like this for ages though.

It was put here as a pull request to help existing AirTime forkees stay legally compliant. The AGPLv3 clearly states:

> Notwithstanding any other provision of this License, if you modify the Program, your modified 
> version must prominently offer all users interacting with it remotely through a computer 
> network (if your version supports such interaction) an opportunity to receive the 
> Corresponding Source of your version by providing access to the Corresponding Source 
> from a network server at no charge, through some standard or customary means of facilitating 
> copying of software.

Basically this means you need to publish your modifications as soon as you let any users interact with the forked code over a non-LAN connection. In the case of Airtime, this clause will trigger in most cases.

Our main branch rabe will have more information on how to use this at https://github.com/radiorabe/airtime.

Further info is available in [README.forking.md](https://github.com/radiorabe/airtime/blob/feature/fork-info/docs/README.forking.md).